### PR TITLE
helper.php: $opts as array for search()

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -97,7 +97,8 @@ class helper_plugin_task extends DokuWiki_Plugin {
 
         // returns the list of pages in the given namespace and it's subspaces
         $items = array();
-        search($items, $dir, 'search_allpages', '');
+        $opts = array();
+        search($items, $dir, 'search_allpages', $opts);
 
         // add pages with comments to result
         $result = array();


### PR DESCRIPTION
# What: changing $opts parameter for search() from '' to an empty array
# Why: DokuWiki errors "Illegal string offset" for 'skipacl' / 'hash' in /inc/search.php
# Note: seems to work fine in Binky
