### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -29,7 +29,7 @@ class action_plugin_task extends DokuWiki_Action_Plugin {
     /**
      * register the eventhandlers
      */
-    function register(&$contr) {
+    function register(Doku_Event_Handler $contr) {
         $contr->register_hook('ACTION_ACT_PREPROCESS',
                             'BEFORE',
                             $this,

--- a/syntax/task.php
+++ b/syntax/task.php
@@ -42,7 +42,7 @@ class syntax_plugin_task_task extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('~~TASK.*?~~', $mode, 'plugin_task_task');
     }
   
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         global $ID;
         global $INFO;
         global $ACT;
@@ -78,7 +78,7 @@ class syntax_plugin_task_task extends DokuWiki_Syntax_Plugin {
         return array($user, $date, $priority);
     }      
  
-    function render($mode, &$renderer, $data) {  
+    function render($mode, Doku_Renderer $renderer, $data) {  
         global $ID;
 
         list($user, $date, $priority) = $data;

--- a/syntax/tasks.php
+++ b/syntax/tasks.php
@@ -36,7 +36,7 @@ class syntax_plugin_task_tasks extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('\{\{tasks>.+?\}\}', $mode, 'plugin_task_tasks');
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         global $ID;
 
         $match = substr($match, 8, -2); // strip {{topic> from start and }} from end
@@ -52,7 +52,7 @@ class syntax_plugin_task_tasks extends DokuWiki_Syntax_Plugin {
         return array($ns, $filter, $flags, $refine);
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         global $conf;
 
         list($ns, $filter, $flags, $refine) = $data;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.