### PR TITLE
Added posibility to set the priority colors using the "Template Style settings" page.

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -2,8 +2,9 @@
 /**
  * Options for the Task Plugin
  */
-$conf['datefield']          = 1;        // entry field for due date in form
-$conf['tasks_formposition'] = 'bottom'; // position of new task form
-$conf['tasks_newestfirst']  = 0;        // show newest tasks first in tasks list
+$conf['datefield']          = 1;          // entry field for due date in form
+$conf['tasks_formposition'] = 'bottom';   // position of new task form
+$conf['tasks_newestfirst']  = 0;          // show newest tasks first in tasks list
+$conf['layout']             = 'built-in'; // use standard layout/colors
 
 //Setup VIM: ex: et ts=2 enc=utf-8 :

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -11,5 +11,9 @@ $meta['tasks_formposition'] = array(
                                 '_choices' => array('none', 'top', 'bottom')
                               );
 $meta['tasks_newestfirst']  = array('onoff');
+$meta['layout']             = array(
+                                'multichoice',
+                                '_choices' => array('built-in', 'template')
+                              );
 
 //Setup VIM: ex: et ts=2 enc=utf-8 :

--- a/helper.php
+++ b/helper.php
@@ -134,6 +134,13 @@ class helper_plugin_task extends DokuWiki_Plugin {
                 elseif (($date + 86400 > time()) && ($filter == 'overdue')) continue;
             } 
 
+            if ($this->getConf('layout') == 'template') {
+                $class = 'template_priority'.$task['priority'];
+            } else {
+                // let pagelist plugin set the class, will be 'priority'
+                $class = NULL;
+            }
+
             $result[$task['key']] = array(
                     'id'       => $id,
                     'date'     => $date,
@@ -143,6 +150,7 @@ class helper_plugin_task extends DokuWiki_Plugin {
                     'perm'     => $perm,
                     'file'     => $task['file'],
                     'exists'   => true,
+                    'class'    => $class,
                     );
         }
 

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -14,4 +14,6 @@ $lang['tasks_formposition_o_none']   = 'gar nicht';
 $lang['tasks_formposition_o_top']    = 'oben';
 $lang['tasks_formposition_o_bottom'] = 'unten';
 
+$lang['layout']                      = 'Welches Layout/Farben sollen benutzt werden?';
+
 //Setup VIM: ex: et ts=2 enc=utf-8 :

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -16,4 +16,6 @@ $lang['tasks_formposition_o_bottom'] = 'bottom';
 
 $lang['tasks_newewstfirst']          = 'show newewst tasks first in tasks list';
 
+$lang['layout']                      = 'which layout/colors shall be used?';
+
 //Setup VIM: ex: et ts=2 enc=utf-8 :

--- a/style.css
+++ b/style.css
@@ -59,6 +59,10 @@ div.dokuwiki tr.priority1 { background-color: #fff7e8; }
 div.dokuwiki tr.priority2 { background-color: #fff1d9; }
 div.dokuwiki tr.priority3 { background-color: #ffe9c2; }
 
+div.dokuwiki tr.template_priority1 { background-color: __plugin_task_priority1_color__; }
+div.dokuwiki tr.template_priority2 { background-color: __plugin_task_priority2_color__; }
+div.dokuwiki tr.template_priority3 { background-color: __plugin_task_priority3_color__; }
+
 div.dokuwiki div.vcalendar fieldset.due { border: 1px solid #ffa200; }
 div.dokuwiki div.vcalendar fieldset.overdue { border: 1px solid #ff0040; }
 

--- a/syntax/task.php
+++ b/syntax/task.php
@@ -84,7 +84,15 @@ class syntax_plugin_task_task extends DokuWiki_Syntax_Plugin {
             }
 
             $class = ' class="vtodo';
-            if ($priority) $class .= ' priority' . $priority;
+            if ($priority) {
+                if ($this->getConf('layout') == 'template') {
+                    // Take layout from DokuWiki template
+                    $class .= ' template_priority' . $priority;
+                } else {
+                    // Use built-in layout
+                    $class .= ' priority' . $priority;
+                }
+            }
             if ($due) {
                 $class .= ' '.$due;
                 $due = ' class="'.$due.'"';


### PR DESCRIPTION
The admin can set the configuration option ```layout``` to ```built-in```, this will use the normal layout (as before).

If the option is set to ```template``` then the priority colors are taken from less-CSS-values:
```
__plugin_task_priority1_color__
__plugin_task_priority2_color__
__plugin_task_priority3_color__
```
To make this work the following needs to be done manually in the DokuWiki template:
In file ```style.ini```, add these lines:
```
;- Styling settings for task plugin ---------------------------------------
__plugin_task_priority1_color__ = "#fff7e8"
__plugin_task_priority2_color__ = "#fff1d9"
__plugin_task_priority3_color__ = "#ffe9c2"
```
In template langauge file ```en/lang.php```, add these lines:
```
$lang['__plugin_task_priority1_color__'] = 'Plugin Task: choose color for priority "medium"';
$lang['__plugin_task_priority2_color__'] = 'Plugin Task: choose color for priority "high"';
$lang['__plugin_task_priority3_color__'] = 'Plugin Task: choose color for priority "critical"';
```
