### PR TITLE
Fixed bug in new Task creation.

### DIFF
--- a/action.php
+++ b/action.php
@@ -74,6 +74,21 @@ class action_plugin_task extends DokuWiki_Action_Plugin {
                 $user     = $_REQUEST['user'];
                 $date     = $_REQUEST['date'];
                 $priority = $_REQUEST['priority'];
+		
+                switch($priority) {
+                    case $this->getLang('low'):
+			$priority = "";
+		        break;
+                    case $this->getLang('medium'):
+	                $priority = "!";
+		        break;
+                    case $this->getLang('high'):
+                        $priority = "!!";
+                        break;
+                    case $this->getLang('critical'):
+                        $priority = "!!!";
+			break;
+                }
 
                 // create wiki page
                 $data = array(


### PR DESCRIPTION
The "new Task" form (on the {{tasks>[namespace]}} page) does not use exclamation marks to
represent priority but natural language entries from lang[..].
This caused `~~TASK?[priority]~~` entries in pages created by this
form to not conform to the syntax and both priority and due date
(if given in the form) were not correctly interpreted.

I added a "translation step" before new page creation that should
fix this (haven't tested for different languages, but it should
work).